### PR TITLE
Update Rust installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ Here's a quick guide to the repositories where things live:
 
 [wasi-sdk](https://github.com/CraneStation/wasi-sdk) - “WASI SDK” packages for C/C++. If you want to try out compiling C/C++, this is a good place to start. "It's just clang."
 
-[WASI-enabled Rust](https://github.com/alexcrichton/rust/tree/wasi) - Rust toolchain with support for wasm32-unknown-wasi. Rust Nightly builds will have built-in WASI support starting in early April.
-To get started using Rust for targeting WASI, see the [release page](https://github.com/alexcrichton/rust/releases/tag/wasi3).
+WASI-enabled Rust - Rust nightly toolchain with support for wasm32-unknown-wasi:
+
+```
+rustup target add wasm32-unknown-wasi --toolchain nightly
+cargo +nightly build --target wasm32-unknown-wasi
+```
 
 [wasi-sysroot](https://github.com/CraneStation/wasi-sysroot/) - WASI libc sources.
 


### PR DESCRIPTION
The wasi target is now available via Rust nightlies, so no need to pull
in a custom toolchain! (and it works on Windows!). I'm not really sure
what the best place is to document these steps, but I figure here is as
good as any?